### PR TITLE
Feature: Starting Backend on a free port

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "OmnAIView",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "OmnAIView",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",
@@ -1550,17 +1550,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -4037,75 +4026,6 @@
       },
       "engines": {
         "node": ">= 12.20.55"
-      }
-    },
-    "node_modules/electron-installer-common": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.4.tgz",
-      "integrity": "sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@electron/asar": "^3.2.5",
-        "@malept/cross-spawn-promise": "^1.0.0",
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.0",
-        "glob": "^7.1.4",
-        "lodash": "^4.17.15",
-        "parse-author": "^2.0.0",
-        "semver": "^7.1.1",
-        "tmp-promise": "^3.0.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/electron-userland/electron-installer-common?sponsor=1"
-      },
-      "optionalDependencies": {
-        "@types/fs-extra": "^9.0.1"
-      }
-    },
-    "node_modules/electron-installer-common/node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-installer-common/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/electron-squirrel-startup": {
@@ -10572,28 +10492,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tmp": "^0.2.0"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OmnAIView",
   "productName": "OmnAIView",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OmnAIView electron App",
   "main": "dist/main.js",
   "scripts": {

--- a/electron/src/omnaiBackend.ts
+++ b/electron/src/omnaiBackend.ts
@@ -1,14 +1,13 @@
 import {spawn, ChildProcess } from "child_process"; 
 import {join} from "path"; 
-import { existsSync } from "fs-extra";
+import { existsSync } from "fs";
 import {app} from "electron"; 
 import * as net from 'net';
-import { AddressInfo } from 'net';
 
 export const omnaiscopeBackendManager = (()=> { // singelton for only one possible encapsulated instance of the backend 
     let backendProcess : ChildProcess | null = null; 
 
-    function isAddressInfo(address: string | AddressInfo | null): address is AddressInfo {
+    function isAddressInfo(address: string | net.AddressInfo | null): address is net.AddressInfo {
         return typeof address === 'object' && address !== null && typeof address.port === 'number';
     }    
 
@@ -22,10 +21,9 @@ export const omnaiscopeBackendManager = (()=> { // singelton for only one possib
                 if (!isAddressInfo(address)) { // check that server.adress is from type AddressInfo
                     return reject(new Error('Error: Port either does not exist or address is not an AddressInfo.'));
                 }
-                else {
-                    const port = (address as net.AddressInfo).port;
-                    server.close(() => resolve(port));
-                }
+
+                const port = (address as net.AddressInfo).port;
+                server.close(() => resolve(port));
             });
         });
     }

--- a/electron/src/omnaiBackend.ts
+++ b/electron/src/omnaiBackend.ts
@@ -2,9 +2,32 @@ import {spawn, ChildProcess } from "child_process";
 import {join} from "path"; 
 import { existsSync } from "fs-extra";
 import {app} from "electron"; 
+import * as net from 'net';
 
 export const omnaiscopeBackendManager = (()=> { // singelton for only one possible encapsulated instance of the backend 
     let backendProcess : ChildProcess | null = null; 
+
+    function testPort(port: number): Promise<boolean>{
+        return new Promise(resolve => {
+            const server = net.createServer(); 
+            server.unref(); //allows the programm to exit if this is the only server running 
+            server.once("error", () => resolve(false)); //first handle errors then listen to skip an internal error
+            server.listen(port, () => { 
+                server.close(() => resolve(true));
+            });
+        });
+    }
+
+    async function getFreePort() : Promise<number>{
+        let start : number = 3000; 
+        let end : number = 10000; 
+
+        for(let port : number = start; port <= end; port ++){
+            const isFree = await testPort(port); 
+            if (isFree) return port; 
+        }
+        throw new Error("No port available"); 
+    }
 
     function getBackendPath(): string {
         const exePath: string = app.isPackaged 
@@ -14,13 +37,15 @@ export const omnaiscopeBackendManager = (()=> { // singelton for only one possib
         return exePath; 
     }
 
-    function startBackend(): void {
+    async function startBackend(): Promise<void> {
         const exePath : string = getBackendPath(); 
 
+        const port : number = await getFreePort(); 
+
         if(existsSync(exePath)){
-            backendProcess = spawn(exePath, ["-w"]); 
-            console.log("Backend process started"); 
-        }
+            backendProcess = spawn(exePath, ["-w", "-p", port.toString()]); 
+            console.log(`Backend process started on port ${port}`);
+        }   
     }
 
     function stopBackend(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OmnAIView",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## What ? 

This PR implements starting the OmnAIScope Dataserver on a free port by passing the backend the port via the spawn command. 

## Why ? 

In the latest version of the OmnAIScope Dataserver, the server requires the client to provide a port in order to start a WebSocket connection. The default port (8080) option has been removed.

## How ? 
A free port is found by attempting to start a server on a certain port to test if this port is free. If a port is unavailable the next on is tried. Starting with port 3000 ending with 10000. Throws an error message if no port is found. 
Once a free port is found, it is passed to the backend using the spawn command. The backend then starts a WebSocket server on the given port.

## Testing 

To test the behavior start the programm with 

``` 
npm start 
```

Expected Behavior: In your task manager you should find the MiniOmni running, when closing the programm MiniOmni should also be closed. In your console you should see the port number on which the backend is running. 

![image](https://github.com/user-attachments/assets/5b328957-c264-40bc-bc05-63affed6e70d)

![image](https://github.com/user-attachments/assets/d155ce95-ff81-4d82-ab97-8871209803a7)

