### PR TITLE
feat(build): Add postinstall script to automate dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "omnaiview-parent",
+  "version": "0.2.0",
+  "description": "Modulares Frontend zur Anzeige und Analyse von Zeitreihendaten",
+  "scripts": {
+    "postinstall": "npm run install:all",
+    "install:all": "npm run install:angular && npm run install:electron",
+    "install:angular": "cd angular-frontend && npm ci",
+    "install:electron": "cd electron && npm ci",
+    "build": "npm run build:angular && npm run build:electron",
+    "build:angular": "cd angular-frontend && npm run build",
+    "build:electron": "cd electron && npm run make",
+    "start:dev": "cd angular-frontend && npm run start",
+    "start:electron": "cd electron && npm run start"
+  }
+}


### PR DESCRIPTION
Implement parent package.json with postinstall hook to automatically run npm ci in all child directories (angular-frontend and electron) when running npm ci in the root directory. This simplifies the initial setup process.