### PR TITLE
Added version-Information prepare-Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ angular-frontend/npm-debug.log
 angular-frontend/yarn-error.log
 
 # IDEs and editors
+.idea
 angular-frontend/.idea/
 angular-frontend/.project
 angular-frontend/.classpath
@@ -30,6 +31,7 @@ angular-frontend/.vscode/*
 angular-frontend/.history/*
 
 # Miscellaneous
+electron/src/version.json
 angular-frontend/.angular/*
 angular-frontend/.angular/cache
 angular-frontend/.sass-cache/

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.2.0",
   "description": "Modulares Frontend zur Anzeige und Analyse von Zeitreihendaten",
   "scripts": {
+    "prepare": "node version-information.js",
     "postinstall": "npm run install:all",
     "install:all": "npm run install:angular && npm run install:electron",
     "install:angular": "cd angular-frontend && npm ci",
     "install:electron": "cd electron && npm ci",
-    "build": "npm run build:angular && npm run build:electron",
+    "build": "npm run prepare build:angular && npm run build:electron",
     "build:angular": "cd angular-frontend && npm run build",
     "build:electron": "cd electron && npm run make",
     "start:dev": "cd angular-frontend && npm run start",

--- a/version-information.js
+++ b/version-information.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const electronPkgPath = path.join(__dirname, 'electron', 'package.json');
+const angularPkgPath = path.join(__dirname, 'angular-frontend', 'package.json');
+
+const electronPkg = JSON.parse(fs.readFileSync(electronPkgPath, 'utf-8'));
+const angularPkg = JSON.parse(fs.readFileSync(angularPkgPath, 'utf-8'));
+
+const versionInfo = {
+    electronVersion: electronPkg.version,
+    angularVersion: angularPkg.version,
+    generatedAt: new Date().toISOString()
+};
+
+const outputPath = path.join(__dirname, '/electron/src/version.json');
+
+fs.writeFileSync(outputPath, JSON.stringify(versionInfo, null, 2), 'utf-8');
+console.log(versionInfo);


### PR DESCRIPTION
This commit adds an npm prepare command which fetches the current build-version from the angular-frontend and electron App.
This is needed for another PR where this information is displayed directly in the Electron App. This PR only displays the information while building and in the version.json file.