### PR TITLE
Add Electron-Menu and change GUI

### DIFF
--- a/angular-frontend/src/app/app.component.html
+++ b/angular-frontend/src/app/app.component.html
@@ -1,5 +1,1 @@
-<nav class="menu-bar" style="padding: 1rem; background: #eee; display: flex; gap: 1rem;">
-  <a routerLink="/graph/main" routerLinkActive="active">Graph Main</a>
-</nav>
-
 <router-outlet></router-outlet>

--- a/electron/forge.config.ts
+++ b/electron/forge.config.ts
@@ -1,9 +1,9 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
-import { MakerSquirrel } from '@electron-forge/maker-squirrel';
-import { MakerZIP } from '@electron-forge/maker-zip';
-import { MakerDeb } from '@electron-forge/maker-deb';
-import { MakerRpm } from '@electron-forge/maker-rpm';
-import { FusesPlugin } from '@electron-forge/plugin-fuses';
+import MakerSquirrel from '@electron-forge/maker-squirrel';
+import MakerZIP from '@electron-forge/maker-zip';
+import MakerDeb from '@electron-forge/maker-deb';
+import MakerRpm from '@electron-forge/maker-rpm';
+import FusesPlugin from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
 
 const config: ForgeConfig = {
@@ -14,19 +14,15 @@ const config: ForgeConfig = {
       "./res/omnai_BE/MiniOmni.exe", 
       "./res/omnai_BE/libusb-1.0.dll",
       "./res/omnai_BE/abseil_dll.dll",
-      "./res/omnai_BE/libprotobuf.dll"
+      "./res/omnai_BE/libprotobuf.dll",
+      "./src/version.json"    
     ],
   },
   rebuildConfig: {},
   makers: [
     new MakerSquirrel({
       setupIcon: './images/icon.ico',
-      // iconUrl: 'https://url/to/icon.ico', 
-      // # If possible, a .ico file hosted by you on a web server should be entered here.
-      // # It would be advisable to use the file from ./images/icon.ico.
-      // # This must be publicly accessible and will then be loaded at _installation time_. It must not be a file://
-      // # https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel.InternalOptions.SquirrelWindowsOptions.html
-      // # It controls the icon, which can be found under Programs.
+      iconUrl: 'https://lugges.s3.nl-ams.scw.cloud/icon-OmnAIView.ico',
     }, ["win32"]), 
     new MakerZIP({}, ['darwin']), 
     new MakerRpm({}), 

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1,15 +1,27 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, shell, Menu, dialog} from 'electron';
 import * as path from "path";
+import * as fs from 'fs';
 import { omnaiscopeBackendManager } from './omnaiBackend';
-
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
   app.quit();
 }
 
+let mainWindow: BrowserWindow;
+
+function getVersionPath(): string {
+  const versionPath: string = app.isPackaged 
+    ? path.join(process.resourcesPath, "version.json")
+    : path.join(__dirname, "..", "src", "version.json")
+
+    return versionPath; 
+}
+
+const versionInfo = JSON.parse(fs.readFileSync(getVersionPath(), 'utf-8'));
+
 const createWindow = (): void => {
   // Create the browser window.
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     icon: "./images/icon",
     height: 600,
     width: 800,
@@ -22,6 +34,84 @@ const createWindow = (): void => {
   const indexPath: string = path.join(__dirname, "..", "res", "angular", "browser", "index.csr.html");
   mainWindow.loadFile(indexPath).catch(err => console.error("Fehler beim Laden der HTML-Datei:", err));
 };
+
+const menuScope = [
+  {
+    label: 'File',
+    submenu: [
+      {
+        label: 'Import',
+        click: async () => {console.log("Clicked File:Import")}
+      },
+      {
+        label: 'Export',
+        click: async () => {console.log("Clicked File:Export")}
+      },
+      {
+        label: 'Close',
+        accelerator: 'CmdOrCtrl+Q',
+        click: () => {
+          app.quit();
+        }
+      }
+    ]
+  },
+
+    {
+  label: 'Analysis',
+  submenu: [
+    {
+      label: 'Minimum',
+      click: async () => {console.log("Clicked Analysis:Minimum")}
+    },
+    {
+      label: 'Maximum',
+      click: async () => {console.log("Clicked Analysis:Maximum")}
+    },
+    {
+      label: 'Median',
+      click: async () => {console.log("Clicked Analysis:Median")}
+    },
+    {
+      label: 'PWM',
+      click: async () => {console.log("Clicked Analysis:PWM")}
+    }
+  ]
+},
+  {
+    label: 'Help',
+    submenu: [{
+      label: 'Information',
+      click: async () => {
+        dialog.showMessageBox(mainWindow, {
+          type: 'info',
+          title: 'Information',
+          message: `electron-v.${versionInfo.electronVersion}\nangular-v.${versionInfo.angularVersion}\n${versionInfo.generatedAt}\n\nMIT © ${new Date().getFullYear()} AI-Gruppe`,
+          buttons: ['OK']
+        })
+      }
+    },
+      {
+        label: 'Support-Website',
+        click: async () => {
+          shell.openExternal("https://omnaiscope.auto-intern.de/support/")
+        }
+      },
+      {
+        label: 'Developer-Tools',
+        accelerator: 'CmdOrCtrl+I',
+        click: () => {
+          if (mainWindow) {
+            mainWindow.webContents.toggleDevTools();
+          }
+        }
+      }
+    ]
+  }
+];
+
+const menu = Menu.buildFromTemplate(menuScope);
+Menu.setApplicationMenu(menu);
 
 omnaiscopeBackendManager.startBackend();
 


### PR DESCRIPTION
This commit changes the Electron Menu and sets entries for Analysis and helper-Information. This PR depends on #35. Electron will crash without the implementation of the other PR.
Currently it is only implemented, that a click on the button fires off a console.log.

Not needed is the "Graph Main" Bar which also has been removed.
This also sets an icon which only is pulled once at installation time, where a user is expected to have internet connection either way. Will fallback to the electron icon.

Kindly