### PR TITLE
No years in X-Axis Timeline

### DIFF
--- a/angular-frontend/src/app/graph/graph.component.ts
+++ b/angular-frontend/src/app/graph/graph.component.ts
@@ -16,6 +16,7 @@ import { DeviceListComponent } from "../omnai-datasource/omnai-scope-server/devi
 import { ResizeObserverDirective } from '../shared/resize-observer.directive';
 import { StartDataButtonComponent } from "../source-selection/start-data-from-source.component";
 import { DataSourceService } from './graph-data.service';
+import { timeFormat } from 'd3-time-format';
 
 @Component({
   selector: 'app-graph',
@@ -49,8 +50,6 @@ export class GraphComponent {
     this.dataservice.updateGraphDimensions(dimension)
   }
 
-  // Axes related computations and
-
   marginTransform = computed(() => {
     return `translate(${this.dataservice.margin.left}, ${this.dataservice.margin.top})`
   })
@@ -65,12 +64,16 @@ export class GraphComponent {
     return `translate(${xScale.range()[0]}, 0)`;
   });
 
-
   updateXAxisInCanvas = effect(() => {
     if (!this.isInBrowser) return;
+    const formatElapsed = timeFormat('%M.%S');
     const x = this.dataservice.xScale()
     const g = this.axesContainer().nativeElement;
-    select(g).transition(transition()).duration(300).call(axisBottom(x));
+    select(g)
+      .transition(transition())
+      .duration(300).
+      call(axisBottom(x).tickFormat(d =>
+        formatElapsed(new Date(Number(d)))));
   });
 
   updateYAxisInCanvas = effect(() => {
@@ -79,5 +82,4 @@ export class GraphComponent {
     const g = this.axesYContainer().nativeElement;
     select(g).transition(transition()).duration(300).call(axisLeft(y));
   });
-
 }


### PR DESCRIPTION
This PR fixes the X-Axis in the Graph. Instead of showing years it shows now correct timestamps with zero as starting point.