### PR TITLE
Doc: Add CHANGELOG.md for contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dummy data server for debugging live graph rendering (#18)
 - Add Icon (#19)
 - Adding compodoc (#23)
+- Adding changelog information to the Contribution.md (#41)
 
 ### Changed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added 
+- Initial Angular Setup (#8)
+- Initial Electron Setup (#10) 
+- Autostart of OmnAIScope Backend (#11)
+- Start OmnAIScope Backend on a free port (#13)
+- Initial README.md and CONTRIBUTION.md (#14)
+- Add postinstall script (#15)
+- Set up dynamic port handling between Electron and Angular app (#18)
+- Create PortService and ApiService to retrieve device list via REST API (#18)
+- Introduce DeviceListComponent to visualize available devices (#18)
+- Add DataSourceService for reactive data management in the graph (#18)
+- Initialize GraphComponent with zoomable x/y axes using D3 (#18)
+- Implement responsive axis drawing with ResizeObserver directive (#18)
+- Provide default random data source for development and debugging (#18)
+- Establish WebSocket communication with backend for live data (#18)
+- Separate configuration for Electron and dev server environments (#18)
+- Apply basic SSR compatibility (guard browser-only APIs) (#18)
+- Add dummy data server for debugging live graph rendering (#18)
+- Add Icon (#19)
+- Adding compodoc (#23)
+
+### Changed 
+
+- BREAKING CHANGE: Update OmnAIScope Dataserver from v0.4.0 to v0.5.0
+- Modernize codebase to Angular 19 (inject, signals, @if/@for, etc.) (#18)
+- Configure Angular Material with a custom theme (#18)
+- Fix the Port selection for the OmnAIScope backend (#19)
+
+### Removed 
+
+- Deletetion of deprecated Angular 18 patterns (#18)

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -50,7 +50,14 @@ It is expected that commits dont only have a header but also
 2. What did you add/change in the commit ? 
 3. Possible important things to know about the commit 
 
-## 6. Push to Your Fork
+## 6. Document your changes in the changelog 
+
+To keep track of changes between different versions a changelog according to the (keepAChangelog)[https://keepachangelog.com/en/1.1.0/]
+is used. 
+
+It is expected that new changes are documented in this changelog. 
+
+## 7. Push to Your Fork
 
 Push your branch to your fork:
 
@@ -58,7 +65,7 @@ Push your branch to your fork:
 git push origin \<branchname\>
 ```
 
-# Open a Pull Request
+# 8. Open a Pull Request
 
 1. Go to the original repository on GitHub.
 2. Click **New Pull Request**.
@@ -66,13 +73,13 @@ git push origin \<branchname\>
 4. Provide a **clear description** of your changes.
 5. Submit the pull request.
 
-## 8. Review & Approval
+## 9. Review & Approval
 
 - PRs must be reviewed by at least **two maintainers**.
 - Address requested changes by updating your branch and pushing updates.
 - Once approved, the PR will be merged by one of the maintainers. 
 
-## 9. Keep Your Fork Updated
+## 10. Keep Your Fork Updated
 
 To stay up to date with the latest changes: 
 
@@ -89,7 +96,7 @@ Make sure that you have added the upstream to your git repo with:
 git remote add upstream git@github.com:AI-Gruppe/OmnAIView.git
 ```
 
-## 10. Reporting Issues
+## 11. Reporting Issues
 
 If you find a bug or have a feature request, please open an [issue](https://github.com/AI-Gruppe/OmnAIView/issues) and describe it clearly.
 


### PR DESCRIPTION
This PR introduces an inital CHANGELOG.md that includes all changes merged in the master until this PR. 
It also updates CONTRIBUTING.md to define changelog entries as a required part of future pull requests.

### Why ? 

Regarding Issue #38 the changes that were made should be documented in one document. 
As described in Issue #38  (keepAChangelog)[https://keepachangelog.com/en/1.1.0/] provides a template that is best practice for softwareprojects. 

Therefor the CHANGELOG.md is written according to the keepAChangelog standard. 
