### PR TITLE
Changed maximumWarning

### DIFF
--- a/angular-frontend/angular.json
+++ b/angular-frontend/angular.json
@@ -42,7 +42,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "750kB",
                   "maximumError": "1MB"
                 },
                 {


### PR DESCRIPTION
This PR changes the reccuring warning that is displayed while building.

The initial bundle size has consistently exceeded the previous warning threshold of 500 kB by ~23 kB. With upcoming features likely to increase the size further, the warning was no longer meaningful.

Raising the maximumWarning to 750 kB reflects the current project state and avoids unnecessary noise during builds. The maximumError limit remains at 1 MB to ensure we still track significant size regressions.