### PR TITLE
setup(codeowners): automatic PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# this is the list of code owners that are automatically set as code
+# reviewers for a new PR 
+*   @tabeatheunicorn @akmaily @PhilippTheServer @MaxClerkwell
+
+# list of codeowners that are set as code reviewers for md files 
+*.md   @tabeatheunicorn @akmaily @dobe-1 @MaxClerkwell @odinthenerd @PhilippTheServer 


### PR DESCRIPTION
## Summary

**Brief description about the content of your PR and its improvements for the project.**
This PR provides automatic allocation of PR reviewers for new PRs. 

1. What problem does this PR solve? Which concept, bug, or requirement does it address?

As reviewers cannot be requested from contributors which can lead to long response times. 
By automatically assigning code owners, this problem should by partly mitigated

## Design Decisions

**Describe the way your implementation works or what design decisions you made if applicable.**

Added a CODEOWNERS file listing the requested CODEOWNERS for PRs,  See [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)  for more documentation. 

## Testing

None done yet.
## Checklist

Make sure you

- [ x] have read the [contribution guidelines](../CONTRIBUTION.md)
- [x] have added necessary unit/e2e tests if necessary.
- [x ] have added documentation if necessary.